### PR TITLE
Add basic Node server and simple web page

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,5 +45,5 @@ Para rodar a demonstracao local, e necessario ter o Node.js instalado. Navegue a
 npm start
 ```
 
-Depois acesse `http://localhost:3000` para visualizar o formulario de pagamento simples.
+Depois acesse `http://localhost:3000` para visualizar a tela de checkout React integrada ao backend.
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # payply
+
+Projeto de sistema de pagamentos em criptomoedas.
+
+## Arquitetura
+
+### Frontend (React + Web3)
+- Conexao com carteira: wagmi + RainbowKit (MetaMask, WalletConnect, etc.)
+- Tela de checkout cripto: selecao de moeda, valor e botao "Pagar com Cripto".
+- Swap/Conversao: integracao com 1inch/Uniswap para trocar tokens automaticamente.
+- Historico e recibo: mostrar hash, status da transacao e recibo.
+- Compra de cripto (on-ramp): integracao com MoonPay, Transak, Banxa ou opcao manual (Pix, cartao...)
+
+### Backend (Node.js + PostgreSQL + Web3)
+- Webhooks: captura automatica de transacoes na blockchain (Moralis, Alchemy, etc.).
+- Controle de pagamentos: salvar logs, status, valores, token e wallet do usuario.
+- Onboarding de lojistas: cadastro, KYC, configuracao da wallet de recebimento.
+- Emissao de cobrancas: criacao de requests de pagamento em cripto (Pix-like).
+- Conversao cripto-fiat: integracao com APIs de cambio (CoinMarketCap, Coingecko, etc.).
+
+### Infraestrutura
+- Frontend: React + Vite + Tailwind.
+- Backend: Node.js (Express ou Fastify) + PostgreSQL.
+- Blockchain Layer: Ethers.js, web3.js, Moralis ou Alchemy.
+- Servicos externos:
+  - On-ramp: MoonPay / Transak / Banxa.
+  - Swaps: 1inch / Uniswap SDK.
+- Armazenamento: Firebase ou S3 para documentos/KYC.
+- Processamento assincrono: RabbitMQ / Redis (opcional).
+
+## Estrutura do Projeto
+
+```
+frontend/
+backend/
+```
+
+
+
+## Executando
+
+Para rodar a demonstracao local, e necessario ter o Node.js instalado. Navegue ate a pasta `backend` e execute:
+
+```bash
+npm start
+```
+
+Depois acesse `http://localhost:3000` para visualizar o formulario de pagamento simples.
+

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,14 @@
+# Backend
+
+Servidor simples em Node.js para exemplificar pagamentos em cripto.
+
+## Executar
+
+```bash
+npm start
+```
+
+O servidor vai rodar em `http://localhost:3000` e expor endpoints:
+- `POST /api/payments` para criar um pagamento
+- `GET /api/payments/:id` para consultar o status
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "payply-backend",
+  "version": "0.1.0",
+  "description": "Backend para o sistema de pagamentos cripto",
+  "main": "src/server.js",
+  "scripts": {
+    "start": "node src/server.js"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -1,0 +1,73 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+let payments = {};
+let counter = 1;
+
+function serveStatic(res, filePath, contentType = 'text/html') {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(500);
+      res.end('Error loading file');
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/') {
+    const file = path.join(__dirname, '../../frontend/index.html');
+    serveStatic(res, file);
+  } else if (req.method === 'POST' && req.url === '/api/payments') {
+    let body = '';
+    req.on('data', chunk => body += chunk);
+    req.on('end', () => {
+      try {
+        const { amount, currency } = JSON.parse(body || '{}');
+        const id = counter++;
+        payments[id] = { id, amount, currency, status: 'pending' };
+        res.writeHead(201, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(payments[id]));
+      } catch (e) {
+        res.writeHead(400);
+        res.end('Invalid JSON');
+      }
+    });
+  } else if (req.method === 'GET' && req.url.startsWith('/api/payments/')) {
+    const id = req.url.split('/').pop();
+    const payment = payments[id];
+    if (!payment) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(payment));
+  } else if (req.method === 'GET' && req.url.startsWith('/')) {
+    // Serve other static files from frontend directory
+    const file = path.join(__dirname, '../../frontend', req.url);
+    if (fs.existsSync(file) && fs.statSync(file).isFile()) {
+      const ext = path.extname(file);
+      const type = {
+        '.js': 'text/javascript',
+        '.css': 'text/css',
+        '.html': 'text/html'
+      }[ext] || 'application/octet-stream';
+      serveStatic(res, file, type);
+    } else {
+      res.writeHead(404);
+      res.end();
+    }
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend
+
+Estrutura inicial para a aplicacao React + Web3.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Payply Checkout</title>
+</head>
+<body>
+  <h1>Payply Checkout</h1>
+  <form id="payment-form">
+    <input type="text" id="amount" placeholder="Amount" required>
+    <input type="text" id="currency" placeholder="Currency" required>
+    <button type="submit">Pay with Crypto</button>
+  </form>
+  <pre id="result"></pre>
+  <script>
+    const form = document.getElementById('payment-form');
+    form.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const amount = document.getElementById('amount').value;
+      const currency = document.getElementById('currency').value;
+      const res = await fetch('/api/payments', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ amount, currency })
+      });
+      const data = await res.json();
+      document.getElementById('result').textContent = JSON.stringify(data, null, 2);
+    });
+  </script>
+</body>
+</html>
+

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,30 +3,48 @@
 <head>
   <meta charset="UTF-8">
   <title>Payply Checkout</title>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <style>
+    body { font-family: Arial, sans-serif; padding: 20px; }
+    form { margin-bottom: 1em; }
+    input { margin-right: .5em; }
+  </style>
 </head>
 <body>
-  <h1>Payply Checkout</h1>
-  <form id="payment-form">
-    <input type="text" id="amount" placeholder="Amount" required>
-    <input type="text" id="currency" placeholder="Currency" required>
-    <button type="submit">Pay with Crypto</button>
-  </form>
-  <pre id="result"></pre>
-  <script>
-    const form = document.getElementById('payment-form');
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const amount = document.getElementById('amount').value;
-      const currency = document.getElementById('currency').value;
-      const res = await fetch('/api/payments', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ amount, currency })
-      });
-      const data = await res.json();
-      document.getElementById('result').textContent = JSON.stringify(data, null, 2);
-    });
+  <div id="root"></div>
+  <script type="text/babel">
+    function App() {
+      const [amount, setAmount] = React.useState('');
+      const [currency, setCurrency] = React.useState('');
+      const [result, setResult] = React.useState('');
+
+      const handleSubmit = async (e) => {
+        e.preventDefault();
+        const res = await fetch('/api/payments', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ amount, currency })
+        });
+        const data = await res.json();
+        setResult(JSON.stringify(data, null, 2));
+      };
+
+      return (
+        <div>
+          <h1>Payply Checkout</h1>
+          <form onSubmit={handleSubmit}>
+            <input value={amount} onChange={e => setAmount(e.target.value)} placeholder="Amount" required />
+            <input value={currency} onChange={e => setCurrency(e.target.value)} placeholder="Currency" required />
+            <button type="submit">Pay with Crypto</button>
+          </form>
+          <pre>{result}</pre>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
   </script>
 </body>
 </html>
-


### PR DESCRIPTION
## Summary
- implement a minimal Node.js backend with in-memory payments
- create a static HTML checkout page that calls the backend
- document how to run the demo server

## Testing
- `npm start` within `backend` started the server
- `node src/server.js` also started and logged "Server listening on port 3000"

------
https://chatgpt.com/codex/tasks/task_e_684743000ff0832b8f5d500369755377